### PR TITLE
Fixing an issue with the POM file that was preventing VS Code from detecting the main method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,7 @@
 ## Version 0.3.0
 
 * Upgrade Confluent Plugin to version 1.20-42
+
+## Version 0.3.1
+
+* Fixing an issue with the POM file that was preventing VS Code from detecting the main method.

--- a/solutions/01-connecting-to-confluent-cloud/pom.xml
+++ b/solutions/01-connecting-to-confluent-cloud/pom.xml
@@ -235,7 +235,6 @@ under the License.
                                         <versionRange>[3.1,)</versionRange>
                                         <goals>
                                             <goal>testCompile</goal>
-                                            <goal>compile</goal>
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>

--- a/solutions/02-querying-flink-tables/pom.xml
+++ b/solutions/02-querying-flink-tables/pom.xml
@@ -235,7 +235,6 @@ under the License.
                                         <versionRange>[3.1,)</versionRange>
                                         <goals>
                                             <goal>testCompile</goal>
-                                            <goal>compile</goal>
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>

--- a/solutions/03-building-a-streaming-pipeline/pom.xml
+++ b/solutions/03-building-a-streaming-pipeline/pom.xml
@@ -235,7 +235,6 @@ under the License.
                                         <versionRange>[3.1,)</versionRange>
                                         <goals>
                                             <goal>testCompile</goal>
-                                            <goal>compile</goal>
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>

--- a/solutions/04-windowing/pom.xml
+++ b/solutions/04-windowing/pom.xml
@@ -235,7 +235,6 @@ under the License.
                                         <versionRange>[3.1,)</versionRange>
                                         <goals>
                                             <goal>testCompile</goal>
-                                            <goal>compile</goal>
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>

--- a/solutions/05-joins/pom.xml
+++ b/solutions/05-joins/pom.xml
@@ -235,7 +235,6 @@ under the License.
                                         <versionRange>[3.1,)</versionRange>
                                         <goals>
                                             <goal>testCompile</goal>
-                                            <goal>compile</goal>
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>

--- a/staging/01-connecting-to-confluent-cloud/pom.xml
+++ b/staging/01-connecting-to-confluent-cloud/pom.xml
@@ -235,7 +235,6 @@ under the License.
                                         <versionRange>[3.1,)</versionRange>
                                         <goals>
                                             <goal>testCompile</goal>
-                                            <goal>compile</goal>
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>


### PR DESCRIPTION
## Description

Fixing an issue with the POM file that was preventing VS Code from detecting the main method.

## Checklist

- [x] Unit tests created/updated for any new code (where applicable).
- [x] Run all tests with `./build.sh validate`.
- [x] Update the [CHANGELOG.md](CHANGELOG.md).
- [x] Update the [README.md](README.md) if necessary.